### PR TITLE
Use env to specify the Bash executable

### DIFF
--- a/zfs-health-check-and-notification.sh
+++ b/zfs-health-check-and-notification.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 #### SET PATHS ####
 


### PR DESCRIPTION
For more information: [Why is #!/usr/bin/env bash superior to #!/bin/bash?](https://stackoverflow.com/questions/21612980/why-is-usr-bin-env-bash-superior-to-bin-bash)