### PR TITLE
fixed line 77 to avoid grepping the word state more than once

### DIFF
--- a/zfs-health-check-and-notification.sh
+++ b/zfs-health-check-and-notification.sh
@@ -74,7 +74,7 @@ do
   fi
 
   # Get the overall pool state and set notfication text.
-  poolOverallCondition=$(/sbin/zpool status ${pool} | grep state | awk '{print $2}')
+  poolOverallCondition=$(/sbin/zpool status ${pool} | awk '/state:/ {print $2})
   poolConditionText="${poolConditionSubText} Overall state is reporting as **${poolOverallCondition}** for this pool."
 
 


### PR DESCRIPTION
Fixed as per issue https://github.com/norsemangrey/zfs-health-check/issues/4

If the pool is degraded, the original syntax returns multiple grep matches for 'state' which breaks the webhook e.g.

```
xxxxxx@bigbox:~/zfs-health-check$ sudo /sbin/zpool status ${pool} | grep state | awk '{print $2}'
DEGRADED
state.
ONLINE

xxxxxx@bigbox:~/zfs-health-check$ sudo zpool status
  pool: vault
 state: DEGRADED
status: One or more devices are faulted in response to persistent errors.
        Sufficient replicas exist for the pool to continue functioning in a
        degraded state.
action: Replace the faulted device, or use 'zpool clear' to mark the device
        repaired.
  scan: scrub repaired 928K in 21:40:52 with 0 errors on Mon Mar  3 21:45:53 2025
config:

        NAME        STATE     READ WRITE CKSUM
        vault       DEGRADED     0     0     0
          raidz1-0  DEGRADED     0     0     0
            sda     ONLINE       0     0     0
            sdb     ONLINE       0     0     0
            sdc     ONLINE       0     0     0
            sdd     FAULTED     24     0     2  too many errors

errors: No known data errors

  pool: vmfs
 state: ONLINE
  scan: scrub repaired 0B in 00:02:59 with 0 errors on Tue Mar  4 00:08:00 2025
config:

        NAME                                  STATE     READ WRITE CKSUM
        vmfs                                  ONLINE       0     0     0
          mirror-0                            ONLINE       0     0     0
            nvme-CT2000T500SSD8_24494CEA16FA  ONLINE       0     0     0
            nvme-CT2000T500SSD8_24494CEB2362  ONLINE       0     0     0

errors: No known data errors
```